### PR TITLE
添加蓝图的方式注册接口到swagger，可省略@siwa.doc装饰器

### DIFF
--- a/flask_siwadoc/__init__.py
+++ b/flask_siwadoc/__init__.py
@@ -145,14 +145,10 @@ class SiwaDoc:
                             is_single_file_ = file_conf.get('single', True)
                             file_list = request_files.getlist(file_field)
                             if is_required_ and not file_list:
-                                raise ValidationError(
-                                    PydanticError(errors=[ErrorWrapper(exc=MissingError(), loc=(file_field,))],
-                                                  model=form_model))
+                                raise ValidationError(PydanticError(errors=[ErrorWrapper(exc=MissingError(), loc=(file_field,))], model=form_model))
 
                             if file_list and is_single_file_ and len(file_list) > 1:
-                                raise ValidationError(PydanticError(
-                                    errors=[ErrorWrapper(exc=ListMaxLengthError(limit_value=1), loc=(file_field,))],
-                                    model=form_model))
+                                raise ValidationError(PydanticError(errors=[ErrorWrapper(exc=ListMaxLengthError(limit_value=1), loc=(file_field,))], model=form_model))
 
                             if file_list:
                                 files_data[file_field] = file_list[0] if is_single_file_ else file_list
@@ -169,7 +165,7 @@ class SiwaDoc:
                 return func(*args, **kwargs)
 
             for model, name in zip(
-                (query, header, cookie, body, form, resp), ('query', 'header', 'cookie', 'body', 'form', 'resp')
+                    (query, header, cookie, body, form, resp), ('query', 'header', 'cookie', 'body', 'form', 'resp')
             ):
                 if model:
                     assert issubclass(model, BaseModel)
@@ -183,8 +179,7 @@ class SiwaDoc:
                             if is_single_file:
                                 file_schema = {'title': field, 'type': 'string', 'format': 'binary'}
                             else:
-                                file_schema = {'title': field, 'type': 'array',
-                                               'items': {'type': 'string', 'format': 'binary'}}
+                                file_schema = {'title': field, 'type': 'array', 'items': {'type': 'string', 'format': 'binary'}}
                             schema['properties'][field] = file_schema
 
                             is_required = conf.get('required', False)

--- a/flask_siwadoc/__init__.py
+++ b/flask_siwadoc/__init__.py
@@ -1,9 +1,9 @@
 import os
 from functools import wraps
-from typing import Optional, Type, Dict
+from typing import Optional, Type, Dict, Callable, TypeVar, Any
 
 import pydantic
-from flask import Blueprint, request, Flask, render_template
+from flask import Blueprint, request, Flask, render_template, typing as ft
 from flask import jsonify
 from pydantic import BaseModel
 from pydantic.typing import Literal
@@ -20,6 +20,7 @@ __all__ = ["SiwaDoc", "ValidationError"]
 __version__ = "0.2.0"
 
 SUPPORTED_UI = ('redoc', 'swagger', 'rapidoc')
+T_route = TypeVar("T_route", bound=ft.RouteCallable)
 
 
 class SiwaDoc:
@@ -144,10 +145,14 @@ class SiwaDoc:
                             is_single_file_ = file_conf.get('single', True)
                             file_list = request_files.getlist(file_field)
                             if is_required_ and not file_list:
-                                raise ValidationError(PydanticError(errors=[ErrorWrapper(exc=MissingError(), loc=(file_field,))], model=form_model))
+                                raise ValidationError(
+                                    PydanticError(errors=[ErrorWrapper(exc=MissingError(), loc=(file_field,))],
+                                                  model=form_model))
 
                             if file_list and is_single_file_ and len(file_list) > 1:
-                                raise ValidationError(PydanticError(errors=[ErrorWrapper(exc=ListMaxLengthError(limit_value=1), loc=(file_field,))], model=form_model))
+                                raise ValidationError(PydanticError(
+                                    errors=[ErrorWrapper(exc=ListMaxLengthError(limit_value=1), loc=(file_field,))],
+                                    model=form_model))
 
                             if file_list:
                                 files_data[file_field] = file_list[0] if is_single_file_ else file_list
@@ -164,7 +169,7 @@ class SiwaDoc:
                 return func(*args, **kwargs)
 
             for model, name in zip(
-                    (query, header, cookie, body, form, resp), ('query', 'header', 'cookie', 'body', 'form', 'resp')
+                (query, header, cookie, body, form, resp), ('query', 'header', 'cookie', 'body', 'form', 'resp')
             ):
                 if model:
                     assert issubclass(model, BaseModel)
@@ -178,7 +183,8 @@ class SiwaDoc:
                             if is_single_file:
                                 file_schema = {'title': field, 'type': 'string', 'format': 'binary'}
                             else:
-                                file_schema = {'title': field, 'type': 'array', 'items': {'type': 'string', 'format': 'binary'}}
+                                file_schema = {'title': field, 'type': 'array',
+                                               'items': {'type': 'string', 'format': 'binary'}}
                             schema['properties'][field] = file_schema
 
                             is_required = conf.get('required', False)
@@ -204,3 +210,69 @@ class SiwaDoc:
             return wrapper
 
         return decorate_validate
+
+    def blueprint(self, *args, **kwargs):
+        return SiwaBlueprint(self, *args, **kwargs)
+
+
+class SiwaBlueprint(Blueprint):
+    siwa: SiwaDoc
+    tags = []
+    group = None
+
+    def __init__(self, siwa: SiwaDoc, *args, **kwargs):
+        self.siwa = siwa
+        if 'tags' in kwargs:
+            self.tags = kwargs.pop('tags')
+        if 'group' in kwargs:
+            self.group = kwargs.pop('group')
+
+        super().__init__(*args, **kwargs)
+
+    def route(self,
+              rule,
+              *,
+              query: Optional[Type[BaseModel]] = None,
+              header: Optional[Type[BaseModel]] = None,
+              cookie: Optional[Type[BaseModel]] = None,
+              body: Optional[Type[BaseModel]] = None,
+              form: Optional[Type[BaseModel]] = None,
+              files=None,
+              resp=None,
+              x=[],
+              tags=[],
+              group=None,
+              summary=None,
+              description=None,
+              ignore=False,
+              **options: Any) -> Callable[[T_route], T_route]:
+
+        # 忽略不使用 siwadoc 的接口
+        if ignore:
+            return super().route(rule, **options)
+
+        def decorator(func) -> T_route:
+            view_func = self.siwa.doc(query,
+                                      header,
+                                      cookie,
+                                      body,
+                                      form,
+                                      files,
+                                      resp,
+                                      x,
+                                      tags or self.tags,
+                                      group or self.group,
+                                      summary,
+                                      description)(func)
+            view = self.__blueprint_route(view_func, rule, **options)
+
+            @wraps
+            def inner(*args, **kwargs):
+                return view(*args, **kwargs)
+
+            return inner
+
+        return decorator
+
+    def __blueprint_route(self, view_func, rule, **options):
+        return super().route(rule, **options)(view_func)

--- a/flask_siwadoc/__init__.py
+++ b/flask_siwadoc/__init__.py
@@ -1,9 +1,9 @@
 import os
 from functools import wraps
-from typing import Optional, Type, Dict
+from typing import Optional, Type, Dict, Callable, TypeVar, Any
 
 import pydantic
-from flask import Blueprint, request, Flask, render_template
+from flask import Blueprint, request, Flask, render_template, typing as ft
 from flask import jsonify
 from pydantic import BaseModel
 from pydantic.typing import Literal
@@ -20,6 +20,7 @@ __all__ = ["SiwaDoc", "ValidationError"]
 __version__ = "0.2.0"
 
 SUPPORTED_UI = ('redoc', 'swagger', 'rapidoc')
+T_route = TypeVar("T_route", bound=ft.RouteCallable)
 
 
 class SiwaDoc:
@@ -204,3 +205,69 @@ class SiwaDoc:
             return wrapper
 
         return decorate_validate
+
+    def blueprint(self, *args, **kwargs):
+        return SiwaBlueprint(self, *args, **kwargs)
+
+
+class SiwaBlueprint(Blueprint):
+    siwa: SiwaDoc
+    tags = []
+    group = None
+
+    def __init__(self, siwa: SiwaDoc, *args, **kwargs):
+        self.siwa = siwa
+        if 'tags' in kwargs:
+            self.tags = kwargs.pop('tags')
+        if 'group' in kwargs:
+            self.group = kwargs.pop('group')
+
+        super().__init__(*args, **kwargs)
+
+    def route(self,
+              rule,
+              *,
+              query: Optional[Type[BaseModel]] = None,
+              header: Optional[Type[BaseModel]] = None,
+              cookie: Optional[Type[BaseModel]] = None,
+              body: Optional[Type[BaseModel]] = None,
+              form: Optional[Type[BaseModel]] = None,
+              files=None,
+              resp=None,
+              x=[],
+              tags=[],
+              group=None,
+              summary=None,
+              description=None,
+              ignore=False,
+              **options: Any) -> Callable[[T_route], T_route]:
+
+        # 忽略不使用 siwadoc 的接口
+        if ignore:
+            return super().route(rule, **options)
+
+        def decorator(func) -> T_route:
+            view_func = self.siwa.doc(query,
+                                      header,
+                                      cookie,
+                                      body,
+                                      form,
+                                      files,
+                                      resp,
+                                      x,
+                                      tags or self.tags,
+                                      group or self.group,
+                                      summary,
+                                      description)(func)
+            view = self.__blueprint_route(view_func, rule, **options)
+
+            @wraps
+            def inner(*args, **kwargs):
+                return view(*args, **kwargs)
+
+            return inner
+
+        return decorator
+
+    def __blueprint_route(self, view_func, rule, **options):
+        return super().route(rule, **options)(view_func)


### PR DESCRIPTION
@lzjun567 你好，我使用了您的 flask-siwadoc 项目，对我有很大帮助。
我为了减少每个接口都要写装饰器，对蓝图进行了封装。
如果我的pr您能接受，我很感谢您。
以下是新增的蓝图方式：

<img width="807" alt="image" src="https://user-images.githubusercontent.com/24733763/226875068-c8e00286-08c5-4796-8573-94ef2f35cd01.png">

1. tags、group 参数可以通过蓝图传递，作用于所有当前蓝图所注册的接口。
2. route 的参数优先级高于蓝图，因此可以针对接口重写 tags、group。
3. route 增加参数 ignore 用于忽略掉某些接口不进入swagger文档中。
